### PR TITLE
Add hook for extending PongHandler

### DIFF
--- a/session.go
+++ b/session.go
@@ -74,14 +74,20 @@ loop:
 	}
 }
 
+func (s *Session) SetPongHandler(f func() error) {
+	s.conn.SetPongHandler(func(string) error {
+		s.conn.SetReadDeadline(time.Now().Add(s.melody.Config.PongWait))
+		return f()
+	})
+}
+
 func (s *Session) readPump() {
 	defer s.conn.Close()
 
 	s.conn.SetReadLimit(s.melody.Config.MaxMessageSize)
 	s.conn.SetReadDeadline(time.Now().Add(s.melody.Config.PongWait))
 
-	s.conn.SetPongHandler(func(string) error {
-		s.conn.SetReadDeadline(time.Now().Add(s.melody.Config.PongWait))
+	s.SetPongHandler(func() error {
 		return nil
 	})
 


### PR DESCRIPTION
This allows the user to know when pongs are received and add their own functionality when this occurs.  The handler can be set when connection is established (HandleConnect function), since the value set by readPump will be able to be overwritten at this point.

Example usage:
```
m.HandleConnect(func(s *melody.Session) {
    s.SetPongHandler(func() error {
        // Do your thing...
        return nil
    })
})
```