### PR TITLE
Add control message support

### DIFF
--- a/examples/gophers/main.go
+++ b/examples/gophers/main.go
@@ -1,14 +1,16 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/olahol/melody"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/olahol/melody"
 )
 
+// GopherInfo contains information about the gopher on screen
 type GopherInfo struct {
 	ID, X, Y string
 }
@@ -35,7 +37,7 @@ func main() {
 		}
 		gophers[s] = &GopherInfo{strconv.Itoa(counter), "0", "0"}
 		s.Write([]byte("iam " + gophers[s].ID))
-		counter += 1
+		counter++
 		lock.Unlock()
 	})
 

--- a/melody.go
+++ b/melody.go
@@ -163,7 +163,7 @@ func (m *Melody) HandleRequest(w http.ResponseWriter, r *http.Request) error {
 // HandleRequestWithKeys does the same as HandleRequest but populates session.Keys with keys.
 func (m *Melody) HandleRequestWithKeys(w http.ResponseWriter, r *http.Request, keys map[string]interface{}) error {
 	if m.hub.closed() {
-		return errors.New("Melody instance is closed.")
+		return errors.New("melody instance is closed")
 	}
 
 	conn, err := m.Upgrader.Upgrade(w, r, nil)
@@ -204,7 +204,7 @@ func (m *Melody) HandleRequestWithKeys(w http.ResponseWriter, r *http.Request, k
 // Broadcast broadcasts a text message to all sessions.
 func (m *Melody) Broadcast(msg []byte) error {
 	if m.hub.closed() {
-		return errors.New("Melody instance is closed.")
+		return errors.New("melody instance is closed")
 	}
 
 	message := &envelope{t: websocket.TextMessage, msg: msg}
@@ -216,7 +216,7 @@ func (m *Melody) Broadcast(msg []byte) error {
 // BroadcastFilter broadcasts a text message to all sessions that fn returns true for.
 func (m *Melody) BroadcastFilter(msg []byte, fn func(*Session) bool) error {
 	if m.hub.closed() {
-		return errors.New("Melody instance is closed.")
+		return errors.New("melody instance is closed")
 	}
 
 	message := &envelope{t: websocket.TextMessage, msg: msg, filter: fn}
@@ -235,7 +235,7 @@ func (m *Melody) BroadcastOthers(msg []byte, s *Session) error {
 // BroadcastBinary broadcasts a binary message to all sessions.
 func (m *Melody) BroadcastBinary(msg []byte) error {
 	if m.hub.closed() {
-		return errors.New("Melody instance is closed.")
+		return errors.New("melody instance is closed")
 	}
 
 	message := &envelope{t: websocket.BinaryMessage, msg: msg}
@@ -247,7 +247,7 @@ func (m *Melody) BroadcastBinary(msg []byte) error {
 // BroadcastBinaryFilter broadcasts a binary message to all sessions that fn returns true for.
 func (m *Melody) BroadcastBinaryFilter(msg []byte, fn func(*Session) bool) error {
 	if m.hub.closed() {
-		return errors.New("Melody instance is closed.")
+		return errors.New("melody instance is closed")
 	}
 
 	message := &envelope{t: websocket.BinaryMessage, msg: msg, filter: fn}
@@ -266,7 +266,7 @@ func (m *Melody) BroadcastBinaryOthers(msg []byte, s *Session) error {
 // Close closes the melody instance and all connected sessions.
 func (m *Melody) Close() error {
 	if m.hub.closed() {
-		return errors.New("Melody instance is already closed.")
+		return errors.New("melody instance is already closed")
 	}
 
 	m.hub.exit <- &envelope{t: websocket.CloseMessage, msg: []byte{}}
@@ -278,7 +278,7 @@ func (m *Melody) Close() error {
 // Use the FormatCloseMessage function to format a proper close message payload.
 func (m *Melody) CloseWithMsg(msg []byte) error {
 	if m.hub.closed() {
-		return errors.New("Melody instance is already closed.")
+		return errors.New("melody instance is already closed")
 	}
 
 	m.hub.exit <- &envelope{t: websocket.CloseMessage, msg: msg}

--- a/melody_test.go
+++ b/melody_test.go
@@ -2,7 +2,6 @@ package melody
 
 import (
 	"bytes"
-	"github.com/gorilla/websocket"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +10,8 @@ import (
 	"testing"
 	"testing/quick"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 type TestServer struct {
@@ -145,7 +146,7 @@ func TestLen(t *testing.T) {
 
 		if rand.Float32() < disconnect {
 			conns[i] = nil
-			disconnected += 1
+			disconnected++
 			conn.Close()
 			continue
 		}

--- a/session.go
+++ b/session.go
@@ -115,6 +115,11 @@ func (s *Session) readPump() {
 		return nil
 	})
 
+	s.conn.SetCloseHandler(func(code int, text string) error {
+		s.melody.closeHandler(s, code, text)
+		return nil
+	})
+
 	for {
 		t, message, err := s.conn.ReadMessage()
 

--- a/session.go
+++ b/session.go
@@ -2,10 +2,11 @@ package melody
 
 import (
 	"errors"
-	"github.com/gorilla/websocket"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 // Session wrapper around websocket connections.
@@ -161,6 +162,18 @@ func (s *Session) Close() error {
 	}
 
 	s.writeMessage(&envelope{t: websocket.CloseMessage, msg: []byte{}})
+
+	return nil
+}
+
+// CloseWithMsg closes the session with the provided payload.
+// Use the FormatCloseMessage function to format a proper close message payload.
+func (s *Session) CloseWithMsg(msg []byte) error {
+	if s.closed() {
+		return errors.New("Session is already closed.")
+	}
+
+	s.writeMessage(&envelope{t: websocket.CloseMessage, msg: msg})
 
 	return nil
 }

--- a/session.go
+++ b/session.go
@@ -22,20 +22,20 @@ type Session struct {
 
 func (s *Session) writeMessage(message *envelope) {
 	if s.closed() {
-		s.melody.errorHandler(s, errors.New("Tried to write to closed a session."))
+		s.melody.errorHandler(s, errors.New("tried to write to closed a session"))
 		return
 	}
 
 	select {
 	case s.output <- message:
 	default:
-		s.melody.errorHandler(s, errors.New("Session message buffer is full."))
+		s.melody.errorHandler(s, errors.New("session message buffer is full"))
 	}
 }
 
 func (s *Session) writeRaw(message *envelope) error {
 	if s.closed() {
-		return errors.New("Trie to write to a closed session.")
+		return errors.New("trie to write to a closed session")
 	}
 
 	s.conn.SetWriteDeadline(time.Now().Add(s.melody.Config.WriteWait))
@@ -141,7 +141,7 @@ func (s *Session) readPump() {
 // Write writes message to session.
 func (s *Session) Write(msg []byte) error {
 	if s.closed() {
-		return errors.New("Session is closed.")
+		return errors.New("session is closed")
 	}
 
 	s.writeMessage(&envelope{t: websocket.TextMessage, msg: msg})
@@ -152,7 +152,7 @@ func (s *Session) Write(msg []byte) error {
 // WriteBinary writes a binary message to session.
 func (s *Session) WriteBinary(msg []byte) error {
 	if s.closed() {
-		return errors.New("Session is closed.")
+		return errors.New("session is closed")
 	}
 
 	s.writeMessage(&envelope{t: websocket.BinaryMessage, msg: msg})
@@ -163,7 +163,7 @@ func (s *Session) WriteBinary(msg []byte) error {
 // Close closes session.
 func (s *Session) Close() error {
 	if s.closed() {
-		return errors.New("Session is already closed.")
+		return errors.New("session is already closed")
 	}
 
 	s.writeMessage(&envelope{t: websocket.CloseMessage, msg: []byte{}})
@@ -175,7 +175,7 @@ func (s *Session) Close() error {
 // Use the FormatCloseMessage function to format a proper close message payload.
 func (s *Session) CloseWithMsg(msg []byte) error {
 	if s.closed() {
-		return errors.New("Session is already closed.")
+		return errors.New("session is already closed")
 	}
 
 	s.writeMessage(&envelope{t: websocket.CloseMessage, msg: msg})


### PR DESCRIPTION
This PR adds support for sending control messages to Sessions. Previously, Melody's `Close` function would only close the connection without informing the websocket first. Now there is (optional) support for informing before close. This also includes the ability to be informed when the client is closing the connection and specifically with what code and error string. Finally, I ran Golint on everything and fixed where issues were found. It passes `go vet` without problems.