### PR TITLE
Allow any Origin by default

### DIFF
--- a/melody.go
+++ b/melody.go
@@ -74,6 +74,7 @@ func New() *Melody {
 	upgrader := &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
+		CheckOrigin:     func(r *http.Request) bool { return true },
 	}
 
 	hub := newHub()


### PR DESCRIPTION
While this does make things a bit less secure I think that this is better than not allowing any origins by default, especially since I think we can assume most people are using this with a framework like Gin which allows people to handle CORS up the chain. Not allowing any Origins by default is a higher barrier to entry than the alternative.

Closes #23