### PR TITLE
Remove default close handler which caused abnormal closes

### DIFF
--- a/melody.go
+++ b/melody.go
@@ -89,7 +89,7 @@ func New() *Melody {
 		messageSentHandler:       func(*Session, []byte) {},
 		messageSentHandlerBinary: func(*Session, []byte) {},
 		errorHandler:             func(*Session, error) {},
-		closeHandler:             func(*Session, int, string) error { return nil },
+		closeHandler:             nil,
 		connectHandler:           func(*Session) {},
 		disconnectHandler:        func(*Session) {},
 		pongHandler:              func(*Session) {},

--- a/session.go
+++ b/session.go
@@ -115,10 +115,11 @@ func (s *Session) readPump() {
 		return nil
 	})
 
-	s.conn.SetCloseHandler(func(code int, text string) error {
-		s.melody.closeHandler(s, code, text)
-		return nil
-	})
+	if s.melody.closeHandler != nil {
+		s.conn.SetCloseHandler(func(code int, text string) error {
+			return s.melody.closeHandler(s, code, text)
+		})
+	}
 
 	for {
 		t, message, err := s.conn.ReadMessage()


### PR DESCRIPTION
I didn't realize it until today but the default close handler I introduced in #24 was overriding Gorilla's default close handler which caused connections to close with 1006 "CLOSE_ABNORMAL". This change removes the default close handler and only sets a close handler if one is provided to Melody.