### PR TITLE
Fix concurrent panic

### DIFF
--- a/melody.go
+++ b/melody.go
@@ -174,13 +174,14 @@ func (m *Melody) HandleRequestWithKeys(w http.ResponseWriter, r *http.Request, k
 	}
 
 	session := &Session{
-		Request: r,
-		Keys:    keys,
-		conn:    conn,
-		output:  make(chan *envelope, m.Config.MessageBufferSize),
-		melody:  m,
-		open:    true,
-		rwmutex: &sync.RWMutex{},
+		Request:    r,
+		Keys:       keys,
+		conn:       conn,
+		output:     make(chan *envelope, m.Config.MessageBufferSize),
+		outputDone: make(chan struct{}),
+		melody:     m,
+		open:       true,
+		rwmutex:    &sync.RWMutex{},
 	}
 
 	m.hub.register <- session


### PR DESCRIPTION
if two goroutines exec these two lines nearly the same time:
https://github.com/olahol/melody/blob/master/session.go#L59
https://github.com/olahol/melody/blob/master/session.go#L24

the two goroutines will get the same opening state, and if `close(s.output)` exec first
https://github.com/olahol/melody/blob/master/session.go#L63

`case s.output <- message` will panic:
https://github.com/olahol/melody/blob/master/session.go#L30

try this example to reproduce this bug:
```golang
package main

import (
	"log"
	"sync"
	"time"

	"github.com/gin-gonic/gin"
	"github.com/gorilla/websocket"
	"github.com/olahol/melody"
)

func client(wg *sync.WaitGroup) {
	defer wg.Done()
	c, _, err := websocket.DefaultDialer.Dial("ws://localhost:5000/ws", nil)
	if err != nil {
		log.Fatal("dial:", err)
	}
	defer c.Close()

	text := "test"
	err = c.WriteMessage(websocket.TextMessage, []byte(text))
	if err != nil {
		log.Printf("write: %v", err)
	}

	// try to trigger that melody Session at the server side getting the same opening state before close(s.input)
	time.AfterFunc(time.Second*2, func() {
		c.Close()
	})

	for {
		_, _, err := c.ReadMessage()
		if err != nil {
			return
		}
	}
}

func main() {
	r := gin.Default()
	m := melody.New()

	r.GET("/ws", func(c *gin.Context) {
		m.HandleRequest(c.Writer, c.Request)
	})

	m.HandleMessage(func(s *melody.Session, msg []byte) {
		go func() {
			// try to trigger that getting the same opening state before s.input<-
			for s.Write(msg) == nil {
			}
		}()
	})

	go func() {
		for {
			wg := &sync.WaitGroup{}
			for i := 0; i < 20; i++ {
				wg.Add(1)
				go client(wg)
			}
			wg.Wait()
		}
	}()

	r.Run("localhost:5000")
}
```

then wait for enough time, we will get:

```sh
panic: send on closed channel

goroutine 2105 [running]:
github.com/olahol/melody.(*Session).writeMessage(0xc000483500, 0xc000ba55f0)
        somedir/src/github.com/olahol/melody/session.go:30 +0x6c
github.com/olahol/melody.(*Session).Write(0xc000483500, 0xc000714400, 0x4, 0x200, 0x0, 0x0)
        somedir/src/github.com/olahol/melody/session.go:149 +0x90
main.main.func2.1(0xc000483500, 0xc000714400, 0x4, 0x200)
        somedir/src/github.com/olahol/melody/examples/chat/main.go:50 +0x50
created by main.main.func2
        somedir/src/github.com/olahol/melody/examples/chat/main.go:48 +0x65
```