### PR TITLE
Allow more specific usage/configuration by exposing the underlying websocket connection object

### DIFF
--- a/session.go
+++ b/session.go
@@ -253,3 +253,9 @@ func (s *Session) LocalAddr() net.Addr {
 func (s *Session) RemoteAddr() net.Addr {
 	return s.conn.RemoteAddr()
 }
+
+// WebsocketConnection returns the underlying websocket connection.
+// This can be used to e.g. set/read additional websocket options or to write sychronous messages.
+func (s *Session) WebsocketConnection() *websocket.Conn {
+	return s.conn
+}


### PR DESCRIPTION
For consumers, who have specific use cases like 
- settings certain config options or
- sending sync messages or 
- sending messages of different message types

The underlying websocket connection object shall be exposed. This would allow them to use this lib for the examples mentioned above